### PR TITLE
[FEAT] 엔티티 초반 세팅

### DIFF
--- a/src/main/java/com/beautiflow/chat/ChatMessage.java
+++ b/src/main/java/com/beautiflow/chat/ChatMessage.java
@@ -1,0 +1,46 @@
+package com.beautiflow.chat;
+
+import java.time.LocalDateTime;
+
+import com.beautiflow.global.domain.BaseTimeEntity;
+import com.beautiflow.global.domain.SenderType;
+import com.beautiflow.user.domain.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "messages")
+public class ChatMessage extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private ChatRoom chatRoom;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User sender;
+
+	@Enumerated(EnumType.STRING)
+	private SenderType senderType;
+
+	private String content;
+	private String imageUrl;
+}

--- a/src/main/java/com/beautiflow/chat/ChatRoom.java
+++ b/src/main/java/com/beautiflow/chat/ChatRoom.java
@@ -1,0 +1,47 @@
+package com.beautiflow.chat;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.beautiflow.global.domain.BaseTimeEntity;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.user.domain.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "chat_rooms")
+public class ChatRoom extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Shop shop;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User customer;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User designer;
+
+	@OneToMany(mappedBy = "chatRoom")
+	private List<ChatMessage> messages = new ArrayList<>();
+}

--- a/src/main/java/com/beautiflow/chat/TemplateMessage.java
+++ b/src/main/java/com/beautiflow/chat/TemplateMessage.java
@@ -1,0 +1,43 @@
+package com.beautiflow.chat;
+
+import com.beautiflow.global.domain.SendTimeType;
+import com.beautiflow.shop.domain.Shop;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "template_messages")
+public class TemplateMessage {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Shop shop;
+
+	private String title;
+	private String content;
+	private boolean enabled;
+
+	@Enumerated(EnumType.STRING)
+	private SendTimeType sendTimeType;
+
+	private String tag;
+}

--- a/src/main/java/com/beautiflow/global/common/ApiResponse.java
+++ b/src/main/java/com/beautiflow/global/common/ApiResponse.java
@@ -1,8 +1,8 @@
-package com.beautiflow.common;
+package com.beautiflow.global.common;
 
-import com.beautiflow.common.error.ErrorCode;
-import com.beautiflow.common.error.MemberErrorCode;
-import com.beautiflow.common.success.CommonSuccessCode;
+import com.beautiflow.global.common.error.ErrorCode;
+import com.beautiflow.global.common.error.MemberErrorCode;
+import com.beautiflow.global.common.success.CommonSuccessCode;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import lombok.AccessLevel;

--- a/src/main/java/com/beautiflow/global/common/CommonPageResponse.java
+++ b/src/main/java/com/beautiflow/global/common/CommonPageResponse.java
@@ -1,4 +1,4 @@
-package com.beautiflow.common;
+package com.beautiflow.global.common;
 
 
 import java.util.List;

--- a/src/main/java/com/beautiflow/global/common/config/SwaggerConfig.java
+++ b/src/main/java/com/beautiflow/global/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.beautiflow.common.config;
+package com.beautiflow.global.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/beautiflow/global/common/error/CommonErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/CommonErrorCode.java
@@ -1,4 +1,4 @@
-package com.beautiflow.common.error;
+package com.beautiflow.global.common.error;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/beautiflow/global/common/error/ErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ErrorCode.java
@@ -1,8 +1,8 @@
-package com.beautiflow.common.success;
+package com.beautiflow.global.common.error;
 
 import org.springframework.http.HttpStatus;
 
-public interface SuccessCode {
+public interface ErrorCode {
 
 	HttpStatus getHttpStatus();
 

--- a/src/main/java/com/beautiflow/global/common/error/MemberErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/MemberErrorCode.java
@@ -1,4 +1,4 @@
-package com.beautiflow.common.error;
+package com.beautiflow.global.common.error;
 
 import org.springframework.http.HttpStatus;
 
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode implements ErrorCode{
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "멤버를 찾을 수 없습니다."),
 	INVALID_MEMBER_PARAMETER(HttpStatus.BAD_REQUEST, "MEMBER400", "유효하지 않는 멤버입니다"),
-	DUPLICATE_MEMBER_STUDENTNO(HttpStatus.BAD_REQUEST, "MEMBER401", "이미 가입된 학번입니다"),
 
 	ACCESS_EXPIRED(HttpStatus.BAD_REQUEST,"ACCESS401","액세스 토큰이 만료되었습니다"),
 	DUPLICATE_AUTHORIZE_CODE(HttpStatus.BAD_REQUEST,"ACCESS402","인가 코드 중복 사용"),

--- a/src/main/java/com/beautiflow/global/common/exception/BeautiFlowException.java
+++ b/src/main/java/com/beautiflow/global/common/exception/BeautiFlowException.java
@@ -1,6 +1,6 @@
-package com.beautiflow.common.exception;
+package com.beautiflow.global.common.exception;
 
-import com.beautiflow.common.error.ErrorCode;
+import com.beautiflow.global.common.error.ErrorCode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/beautiflow/global/common/handler/ExceptionAdvice.java
+++ b/src/main/java/com/beautiflow/global/common/handler/ExceptionAdvice.java
@@ -1,4 +1,4 @@
-package com.beautiflow.common.handler;
+package com.beautiflow.global.common.handler;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -11,10 +11,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.beautiflow.common.ApiResponse;
-import com.beautiflow.common.error.CommonErrorCode;
-import com.beautiflow.common.error.ErrorCode;
-import com.beautiflow.common.exception.BeautiFlowException;
+import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.global.common.error.CommonErrorCode;
+import com.beautiflow.global.common.error.ErrorCode;
+import com.beautiflow.global.common.exception.BeautiFlowException;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/beautiflow/global/common/success/CommonSuccessCode.java
+++ b/src/main/java/com/beautiflow/global/common/success/CommonSuccessCode.java
@@ -1,4 +1,4 @@
-package com.beautiflow.common.success;
+package com.beautiflow.global.common.success;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/beautiflow/global/common/success/SuccessCode.java
+++ b/src/main/java/com/beautiflow/global/common/success/SuccessCode.java
@@ -1,8 +1,8 @@
-package com.beautiflow.common.error;
+package com.beautiflow.global.common.success;
 
 import org.springframework.http.HttpStatus;
 
-public interface ErrorCode {
+public interface SuccessCode {
 
 	HttpStatus getHttpStatus();
 

--- a/src/main/java/com/beautiflow/global/domain/ApprovalStatus.java
+++ b/src/main/java/com/beautiflow/global/domain/ApprovalStatus.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum ApprovalStatus { PENDING, APPROVED, REJECTED }

--- a/src/main/java/com/beautiflow/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/beautiflow/global/domain/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package com.beautiflow.global.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public class BaseTimeEntity {
+	@CreationTimestamp
+	private LocalDateTime createdTime;
+	@UpdateTimestamp
+	private LocalDateTime updatedTime;
+}

--- a/src/main/java/com/beautiflow/global/domain/GlobalRole.java
+++ b/src/main/java/com/beautiflow/global/domain/GlobalRole.java
@@ -1,0 +1,4 @@
+package com.beautiflow.global.domain;
+
+public enum GlobalRole { CUSTOMER, STAFF }
+

--- a/src/main/java/com/beautiflow/global/domain/PaymentMethod.java
+++ b/src/main/java/com/beautiflow/global/domain/PaymentMethod.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum PaymentMethod { KAKAO_PAY, BANK_TRANSFER }

--- a/src/main/java/com/beautiflow/global/domain/PaymentStatus.java
+++ b/src/main/java/com/beautiflow/global/domain/PaymentStatus.java
@@ -1,0 +1,2 @@
+package com.beautiflow.global.domain;
+public enum PaymentStatus { UNPAID, PAID, REFUNDED }

--- a/src/main/java/com/beautiflow/global/domain/ReservationStatus.java
+++ b/src/main/java/com/beautiflow/global/domain/ReservationStatus.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum ReservationStatus { PENDING, CONFIRMED, CANCELLED }

--- a/src/main/java/com/beautiflow/global/domain/SendTimeType.java
+++ b/src/main/java/com/beautiflow/global/domain/SendTimeType.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum SendTimeType { BEFORE, AFTER }

--- a/src/main/java/com/beautiflow/global/domain/SenderType.java
+++ b/src/main/java/com/beautiflow/global/domain/SenderType.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum SenderType { CUSTOMER, STAFF }

--- a/src/main/java/com/beautiflow/global/domain/ShopRole.java
+++ b/src/main/java/com/beautiflow/global/domain/ShopRole.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum ShopRole { OWNER, DESIGNER }

--- a/src/main/java/com/beautiflow/global/domain/TreatmentCategory.java
+++ b/src/main/java/com/beautiflow/global/domain/TreatmentCategory.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum TreatmentCategory { hand, feet, cf }

--- a/src/main/java/com/beautiflow/global/domain/WeekDay.java
+++ b/src/main/java/com/beautiflow/global/domain/WeekDay.java
@@ -1,0 +1,3 @@
+package com.beautiflow.global.domain;
+
+public enum WeekDay { SUN, MON, TUE, WED, THU, FRI, SAT }

--- a/src/main/java/com/beautiflow/reservation/domain/Reservation.java
+++ b/src/main/java/com/beautiflow/reservation/domain/Reservation.java
@@ -1,0 +1,76 @@
+package com.beautiflow.reservation.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.beautiflow.global.domain.BaseTimeEntity;
+import com.beautiflow.global.domain.PaymentMethod;
+import com.beautiflow.global.domain.PaymentStatus;
+import com.beautiflow.global.domain.ReservationStatus;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "reservations")
+public class Reservation extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Shop shop;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User customer;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User designer;
+
+	private LocalDate reservationDate;
+	private LocalTime startTime;
+	private LocalTime endTime;
+
+	@Enumerated(EnumType.STRING)
+	private ReservationStatus status;
+
+	private String requestNotes;
+
+	@Column(columnDefinition = "json")
+	private String styleImageUrls;
+
+	@Enumerated(EnumType.STRING)
+	private PaymentMethod paymentMethod;
+
+	@Enumerated(EnumType.STRING)
+	private PaymentStatus paymentStatus;
+
+	@OneToMany(mappedBy = "reservation")
+	private List<ReservationTreatment> reservationTreatments = new ArrayList<>();
+
+	@OneToMany(mappedBy = "reservation")
+	private List<ReservationOption> reservationOptions = new ArrayList<>();
+}
+

--- a/src/main/java/com/beautiflow/reservation/domain/ReservationOption.java
+++ b/src/main/java/com/beautiflow/reservation/domain/ReservationOption.java
@@ -1,0 +1,34 @@
+package com.beautiflow.reservation.domain;
+
+import com.beautiflow.treatment.domain.OptionItem;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "reservation_options")
+public class ReservationOption {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Reservation reservation;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private OptionItem optionItem;
+}

--- a/src/main/java/com/beautiflow/reservation/domain/ReservationTreatment.java
+++ b/src/main/java/com/beautiflow/reservation/domain/ReservationTreatment.java
@@ -1,0 +1,34 @@
+package com.beautiflow.reservation.domain;
+
+import com.beautiflow.treatment.domain.Treatment;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "reservation_treatments")
+public class ReservationTreatment {
+	@EmbeddedId
+	private ReservationTreatmentId id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("reservationId")
+	private Reservation reservation;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("treatmentId")
+	private Treatment treatment;
+}

--- a/src/main/java/com/beautiflow/reservation/domain/ReservationTreatmentId.java
+++ b/src/main/java/com/beautiflow/reservation/domain/ReservationTreatmentId.java
@@ -1,0 +1,18 @@
+package com.beautiflow.reservation.domain;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReservationTreatmentId implements Serializable {
+	private Long reservationId;
+	private Long treatmentId;
+}

--- a/src/main/java/com/beautiflow/shop/domain/BusinessHour.java
+++ b/src/main/java/com/beautiflow/shop/domain/BusinessHour.java
@@ -1,0 +1,44 @@
+package com.beautiflow.shop.domain;
+
+import java.time.LocalTime;
+
+import com.beautiflow.global.domain.WeekDay;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "business_hours")
+public class BusinessHour {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Shop shop;
+
+	@Enumerated(EnumType.STRING)
+	private WeekDay dayOfWeek;
+
+	private LocalTime openTime;
+	private LocalTime closeTime;
+	private LocalTime breakStart;
+	private LocalTime breakEnd;
+	private boolean isClosed;
+}

--- a/src/main/java/com/beautiflow/shop/domain/Shop.java
+++ b/src/main/java/com/beautiflow/shop/domain/Shop.java
@@ -1,0 +1,51 @@
+package com.beautiflow.shop.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.beautiflow.treatment.domain.Treatment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "shops")
+public class Shop {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+	private String contact;
+	private String link;
+	private String accountInfo;
+	private String location;
+	private String introText;
+	private String mainImageUrl;
+
+	@Column(unique = true)
+	private String businessRegistrationNumber;
+
+	@OneToMany(mappedBy = "shop")
+	private List<ShopNotice> notices = new ArrayList<>();
+
+	@OneToMany(mappedBy = "shop")
+	private List<BusinessHour> businessHours = new ArrayList<>();
+
+	@OneToMany(mappedBy = "shop")
+	private List<Treatment> treatments = new ArrayList<>();
+}

--- a/src/main/java/com/beautiflow/shop/domain/ShopMember.java
+++ b/src/main/java/com/beautiflow/shop/domain/ShopMember.java
@@ -1,0 +1,49 @@
+package com.beautiflow.shop.domain;
+
+import java.time.LocalDateTime;
+
+import com.beautiflow.global.domain.ApprovalStatus;
+import com.beautiflow.global.domain.ShopRole;
+import com.beautiflow.user.domain.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "shop_members")
+public class ShopMember {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Shop shop;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	private ShopRole role;
+
+	@Enumerated(EnumType.STRING)
+	private ApprovalStatus status;
+
+	private LocalDateTime appliedAt;
+	private LocalDateTime processedAt;
+}

--- a/src/main/java/com/beautiflow/shop/domain/ShopNotice.java
+++ b/src/main/java/com/beautiflow/shop/domain/ShopNotice.java
@@ -1,0 +1,32 @@
+package com.beautiflow.shop.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "shop_notices")
+public class ShopNotice {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Shop shop;
+
+	private String title;
+	private String content;
+}

--- a/src/main/java/com/beautiflow/treatment/domain/OptionGroup.java
+++ b/src/main/java/com/beautiflow/treatment/domain/OptionGroup.java
@@ -1,0 +1,39 @@
+package com.beautiflow.treatment.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "option_groups")
+public class OptionGroup {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Treatment treatment;
+
+	private String name;
+	private boolean enabled;
+
+	@OneToMany(mappedBy = "optionGroup")
+	private List<OptionItem> items = new ArrayList<>();
+}

--- a/src/main/java/com/beautiflow/treatment/domain/OptionItem.java
+++ b/src/main/java/com/beautiflow/treatment/domain/OptionItem.java
@@ -1,0 +1,33 @@
+package com.beautiflow.treatment.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "option_items")
+public class OptionItem {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private OptionGroup optionGroup;
+
+	private String name;
+	private Integer extraMinutes;
+	private String description;
+}

--- a/src/main/java/com/beautiflow/treatment/domain/Treatment.java
+++ b/src/main/java/com/beautiflow/treatment/domain/Treatment.java
@@ -1,0 +1,52 @@
+package com.beautiflow.treatment.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.beautiflow.global.domain.TreatmentCategory;
+import com.beautiflow.shop.domain.Shop;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "treatments")
+public class Treatment {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Shop shop;
+
+	@Enumerated(EnumType.STRING)
+	private TreatmentCategory category;
+	private String name;
+	private Integer minPrice;
+	private Integer maxPrice;
+	private Integer durationMinutes;
+	private String description;
+
+	@OneToMany(mappedBy = "treatment")
+	private List<TreatmentImage> images = new ArrayList<>();
+
+	@OneToMany(mappedBy = "treatment")
+	private List<OptionGroup> optionGroups = new ArrayList<>();
+}

--- a/src/main/java/com/beautiflow/treatment/domain/TreatmentImage.java
+++ b/src/main/java/com/beautiflow/treatment/domain/TreatmentImage.java
@@ -1,0 +1,31 @@
+package com.beautiflow.treatment.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "treatment_images")
+public class TreatmentImage {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Treatment treatment;
+
+	private String imageUrl;
+}

--- a/src/main/java/com/beautiflow/user/domain/User.java
+++ b/src/main/java/com/beautiflow/user/domain/User.java
@@ -1,0 +1,57 @@
+package com.beautiflow.user.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.beautiflow.global.domain.BaseTimeEntity;
+import com.beautiflow.reservation.domain.Reservation;
+import com.beautiflow.shop.domain.ShopMember;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String kakaoId;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private String contact;
+
+	private String intro;
+
+	@OneToMany(mappedBy = "user")
+	private List<UserRole> roles = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<ShopMember> shopMemberships = new ArrayList<>();
+
+	@OneToMany(mappedBy = "customer")
+	private List<Reservation> reservations = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<UserStyleImage> styleImages = new ArrayList<>();
+}

--- a/src/main/java/com/beautiflow/user/domain/UserRole.java
+++ b/src/main/java/com/beautiflow/user/domain/UserRole.java
@@ -1,0 +1,37 @@
+package com.beautiflow.user.domain;
+
+import com.beautiflow.global.domain.GlobalRole;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "user_roles")
+public class UserRole {
+	@EmbeddedId
+	private UserRoleId id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("userId")
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private GlobalRole role;
+}

--- a/src/main/java/com/beautiflow/user/domain/UserRoleId.java
+++ b/src/main/java/com/beautiflow/user/domain/UserRoleId.java
@@ -1,0 +1,24 @@
+package com.beautiflow.user.domain;
+
+import java.io.Serializable;
+
+import com.beautiflow.global.domain.GlobalRole;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Embeddable
+public class UserRoleId implements Serializable {
+	private Long userId;
+
+	@Enumerated(EnumType.STRING)
+	private GlobalRole role;
+}

--- a/src/main/java/com/beautiflow/user/domain/UserStyleImage.java
+++ b/src/main/java/com/beautiflow/user/domain/UserStyleImage.java
@@ -1,0 +1,34 @@
+package com.beautiflow.user.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "user_style_images")
+public class UserStyleImage {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
+	private String imageUrl;
+	private LocalDateTime createdAt;
+}


### PR DESCRIPTION
## 📄 주요 변경 사항
서비스 전체 엔티티 초기 세팅했습니다.
아래는 오너,디자이너,고객 관련 내용에 대한 설명만 첨부하겠습니다.

- 유저 역할을 유연하게 관리하기 위해 도메인 구조 재설계
- 고객(CUSTOMER), 디자이너(DESIGNER), 사장님(OWNER)의 역할을 분리 저장
- 한 명의 사용자가 다양한 역할 및 샵 소속을 가질 수 있도록 다대다 구조로 설계

---

## ✅ 설계 목적

뷰티샵 예약 시스템 특성상, 한 명의 사용자가 동시에 다음과 같은 복합 역할을 가질 수 있음:

- 고객으로 예약
- 디자이너로 예약을 수행
- 샵 사장님으로 운영
- 여러 샵에 속하거나 운영하는 구조까지 고려

이에 따라 단일 Role 필드로는 유연한 권한 표현이 어려워, 다음과 같은 구조로 분리 설계함.

---

## 🧱 도입 도메인 및 역할

### 1. `users`

- 사용자 기본 정보 (카카오 로그인 기반 식별자, 이름, 연락처 등)
- 모든 사용자의 공통 프로필

### 2. `user_roles`

- 전역 사용자 권한
- Enum: `CUSTOMER`, `STAFF`
- 예) 고객이면서 동시에 직원인 경우 2개 Role을 가질 수 있음
- Composite Key: `(user_id, role)`

### 3. `shop_members`

- 특정 샵에 소속된 사용자 정보
- 역할: `OWNER`, `DESIGNER`
- 상태: `PENDING`, `APPROVED`, `REJECTED`
-  다대다 관계 (한 유저가 여러 샵에, 한 샵에 여러 유저가)

---

<img width="714" alt="image" src="https://github.com/user-attachments/assets/89e3ae89-6a38-436a-86f7-139fd6827b6f" />
