### PR TITLE
[FEAT] 사장님 월별 예약 조회 구현 #13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/beautiflow/user/domain/UserRole.java
+++ b/src/main/java/com/beautiflow/user/domain/UserRole.java
@@ -32,6 +32,7 @@ public class UserRole {
 	private User user;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
+	@Column(name = "role", insertable = false, updatable = false)
 	private GlobalRole role;
+
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#13 

## 🪐 작업 내용
- 사장님 날짜별 예약 유무 캘린더 조회 구현

- ReservationController에 GET /dates 엔드포인트 추가
  - @RequestParam으로 `designerId`와 `month`를 받아 처리
  - 응답은 예약된 날짜 리스트(List<LocalDate>) 반환
  
- ReservationService에 예약 날짜 조회 로직 구현
  - 특정 디자이너 ID와 연-월 기준으로 예약 필터링
  - 예약이 있는 날짜만 중복 제거 후 리스트화
  
- ReservationRepository에 월별 예약 검색 쿼리 작성
  - 예약 날짜(`reservationDate`)를 YearMonth 기준으로 필터링
  - 디자이너 ID와 날짜 조건으로 DB에서 조회
  
- 예약 날짜 응답을 위한 ApiResponse<List<LocalDate>> 구성
  - 별도 DTO 생성 없이 List로 직접 반환
  - 응답 코드 및 메시지 일관성 유지
  
- 로컬 DB에 예약 데이터 insert 후 실제 조회 테스트 완료
  - designer_id = 11, reservation_date = '2025-07-15' 등 확인
  - 예약 없을 경우 빈 배열 `[]` 반환 확인

## 📚 Reference

## ✅ Check List
- [✅ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [✅] merge할 브랜치의 위치를 확인했나요?
- [✅] Label을 지정했나요?
