### PR TITLE
[FEAT] 매장, 시술, 시술 세부 조회 구현

### DIFF
--- a/src/main/java/com/beautiflow/global/common/error/ShopErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ShopErrorCode.java
@@ -1,0 +1,18 @@
+package com.beautiflow.global.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ShopErrorCode implements ErrorCode{
+
+    SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404", "매장을 찾을 수 없습니다."),
+    INVALID_SHOP_PARAMETER(HttpStatus.BAD_REQUEST, "SHOP400", "유효하지 않은 매장 파라미터입니다."),
+    UNAUTHORIZED_SHOP_ACCESS(HttpStatus.FORBIDDEN, "SHOP403", "해당 매장에 접근할 수 있는 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/beautiflow/global/common/error/TreatmentErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/TreatmentErrorCode.java
@@ -1,0 +1,18 @@
+package com.beautiflow.global.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TreatmentErrorCode implements ErrorCode {
+
+    TREATMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "TREATMENT404", "시술을 찾을 수 없습니다."),
+    INVALID_TREATMENT_PARAMETER(HttpStatus.BAD_REQUEST, "TREATMENT400", "유효하지 않은 시술 파라미터입니다."),
+    UNAUTHORIZED_TREATMENT_ACCESS(HttpStatus.FORBIDDEN, "TREATMENT403", "해당 시술에 접근할 수 있는 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/beautiflow/reservation/controller/ShopController.java
+++ b/src/main/java/com/beautiflow/reservation/controller/ShopController.java
@@ -1,0 +1,73 @@
+package com.beautiflow.reservation.controller;
+
+import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.global.common.error.ErrorCode;
+import com.beautiflow.global.common.error.ShopErrorCode;
+import com.beautiflow.global.common.error.TreatmentErrorCode;
+import com.beautiflow.global.common.success.CommonSuccessCode;
+import com.beautiflow.global.common.success.SuccessCode;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse;
+import com.beautiflow.reservation.dto.response.TreatmentResponse;
+import com.beautiflow.reservation.service.ShopService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="Reservation", description = "고객_매장/예약")
+@RestController
+@RequestMapping("/shops")
+@RequiredArgsConstructor
+public class ShopController {
+
+    private final ShopService shopService;
+
+    @Operation(summary = "매장 정보 조회", description = "shopId로 매장 정보 조회")
+    @GetMapping("/{shopId}")
+    public ApiResponse<?> getShopDetail(@PathVariable Long shopId) {
+        try {
+            ShopDetailResponse response = shopService.getShopDetail(shopId);
+            return ApiResponse.success(response);
+        } catch (EntityNotFoundException e) {
+            return ApiResponse.createFail(ShopErrorCode.SHOP_NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @Operation(summary = "매장 내 시술 목록 조회", description = "shopId로 매장 시술 목록 조회, category 필터 가능")
+    @GetMapping("/{shopId}/treatments")
+    public ApiResponse<List<TreatmentResponse>> getTreatmentsByShopAndCategory(
+            @PathVariable Long shopId,
+            @RequestParam(required = false) String category) {
+        try {
+            List<TreatmentResponse> treatments = shopService.getTreatmentsByShopAndCategory(shopId, category);
+            return ApiResponse.success(treatments);
+        } catch (EntityNotFoundException e) {
+            return (ApiResponse<List<TreatmentResponse>>) ApiResponse.createFail(ShopErrorCode.SHOP_NOT_FOUND, e.getMessage());
+        } catch (IllegalArgumentException e) {
+            return (ApiResponse<List<TreatmentResponse>>) ApiResponse.createFail(TreatmentErrorCode.INVALID_TREATMENT_PARAMETER, e.getMessage());
+        }
+    }
+
+    @Operation(summary = "매장 내 특정 시술 상세 조회", description = "shopId와 treatmentId로 특정 시술 상세 정보 조회")
+    @GetMapping("/{shopId}/treatments/{treatmentId}")
+    public ApiResponse<TreatmentResponse> getTreatmentDetail(
+            @PathVariable Long shopId,
+            @PathVariable Long treatmentId) {
+        try {
+            TreatmentResponse response = shopService.getTreatmentDetail(shopId, treatmentId);
+            return ApiResponse.success(response);
+        } catch (EntityNotFoundException e) {
+            if (e.getMessage().contains("시술")) {
+                return (ApiResponse<TreatmentResponse>) ApiResponse.createFail(TreatmentErrorCode.TREATMENT_NOT_FOUND, e.getMessage());
+            } else {
+                return (ApiResponse<TreatmentResponse>) ApiResponse.createFail(ShopErrorCode.SHOP_NOT_FOUND, e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/beautiflow/reservation/converter/ShopConverter.java
+++ b/src/main/java/com/beautiflow/reservation/converter/ShopConverter.java
@@ -1,0 +1,78 @@
+package com.beautiflow.reservation.converter;
+
+import com.beautiflow.reservation.dto.response.ShopDetailResponse;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse.BusinessHourDto;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse.NoticeDto;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse.TreatmentDto;
+import com.beautiflow.shop.domain.BusinessHour;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.shop.domain.ShopNotice;
+import com.beautiflow.treatment.domain.Treatment;
+import com.beautiflow.treatment.domain.TreatmentImage;
+import java.util.stream.Collectors;
+
+public class ShopConverter {
+
+    public static ShopDetailResponse toDto(Shop shop) {
+        return ShopDetailResponse.builder()
+                .id(shop.getId())
+                .name(shop.getName())
+                .contact(shop.getContact())
+                .location(shop.getLocation())
+                .introText(shop.getIntroText())
+                .mainImageUrl(shop.getMainImageUrl())
+                .notices(shop.getNotices().stream()
+                        .map(ShopConverter::toNoticeDto)
+                        .collect(Collectors.toList()))
+                .notices(shop.getNotices().stream()
+                        .map(ShopConverter::toNoticeDto)
+                        .collect(Collectors.toList()))
+                .businessHours(shop.getBusinessHours().stream()
+                        .map(ShopConverter::toBusinessHourDto)
+                        .collect(Collectors.toList()))
+                .treatments(shop.getTreatments().stream()
+                        .map(ShopConverter::toTreatmentDto)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+    private static NoticeDto toNoticeDto(ShopNotice notice) {
+        return NoticeDto.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .build();
+    }
+
+    private static BusinessHourDto toBusinessHourDto(BusinessHour businessHour) {
+        return BusinessHourDto.builder()
+                .dayOfWeek(businessHour.getDayOfWeek())
+                .openTime(businessHour.getOpenTime())
+                .closeTime(businessHour.getCloseTime())
+                .breakStart(businessHour.getBreakStart())
+                .breakEnd(businessHour.getBreakEnd())
+                .isClosed(businessHour.isClosed())
+                .build();
+    }
+
+    private static TreatmentDto toTreatmentDto(Treatment treatment) {
+        return TreatmentDto.builder()
+                .id(treatment.getId())
+                .category(treatment.getCategory())
+                .name(treatment.getName())
+                .minPrice(treatment.getMinPrice())
+                .maxPrice(treatment.getMaxPrice())
+                .durationMinutes(treatment.getDurationMinutes())
+                .description(treatment.getDescription())
+                .images(treatment.getImages().stream()
+                        .map(ShopConverter::toTreatmentImageDto)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private static TreatmentDto.TreatmentImageDto toTreatmentImageDto(TreatmentImage image) {
+        return TreatmentDto.TreatmentImageDto.builder()
+                .id(image.getId())
+                .imageUrl(image.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/beautiflow/reservation/dto/response/ShopDetailResponse.java
+++ b/src/main/java/com/beautiflow/reservation/dto/response/ShopDetailResponse.java
@@ -1,0 +1,61 @@
+package com.beautiflow.reservation.dto.response;
+
+import com.beautiflow.global.domain.TreatmentCategory;
+import com.beautiflow.global.domain.WeekDay;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.Builder;
+
+public record ShopDetailResponse (
+    Long id,
+    String name,
+    String contact,
+    String location,
+    String introText,
+    String mainImageUrl,
+    List<NoticeDto> notices,
+    List<BusinessHourDto> businessHours,
+    List<TreatmentDto> treatments
+
+) {
+    @Builder
+    public ShopDetailResponse {}
+
+    public record NoticeDto(Long id, String title, String content) {
+        @Builder
+        public NoticeDto{}
+    }
+
+    public record BusinessHourDto(
+            WeekDay dayOfWeek,
+            LocalTime openTime,
+            LocalTime closeTime,
+            LocalTime breakStart,
+            LocalTime breakEnd,
+            boolean isClosed
+    ) {
+        @Builder
+        public BusinessHourDto {}
+    }
+
+    public record TreatmentDto(
+            Long id,
+            TreatmentCategory category,
+            String name,
+            Integer minPrice,
+            Integer maxPrice,
+            Integer durationMinutes,
+            String description,
+            List<TreatmentImageDto> images
+    ) {
+
+        @Builder
+        public TreatmentDto {}
+
+        public record TreatmentImageDto(Long id, String imageUrl) {
+
+            @Builder
+            public TreatmentImageDto {}
+        }
+    }
+}

--- a/src/main/java/com/beautiflow/reservation/dto/response/TreatmentImageResponse.java
+++ b/src/main/java/com/beautiflow/reservation/dto/response/TreatmentImageResponse.java
@@ -1,0 +1,7 @@
+package com.beautiflow.reservation.dto.response;
+
+
+public record TreatmentImageResponse(
+        Long id,
+        String imageUrl
+) {}

--- a/src/main/java/com/beautiflow/reservation/dto/response/TreatmentResponse.java
+++ b/src/main/java/com/beautiflow/reservation/dto/response/TreatmentResponse.java
@@ -1,0 +1,32 @@
+package com.beautiflow.reservation.dto.response;
+
+import com.beautiflow.global.domain.TreatmentCategory;
+import com.beautiflow.treatment.domain.Treatment;
+import java.util.List;
+import lombok.Builder;
+
+public record TreatmentResponse(
+        Long id,
+        String category,
+        String name,
+        Integer minPrice,
+        Integer maxPrice,
+        Integer durationMinutes,
+        String description,
+        List<TreatmentImageResponse> images
+) {
+    public static TreatmentResponse from(Treatment treatment) {
+        return new TreatmentResponse(
+                treatment.getId(),
+                treatment.getCategory().name(),
+                treatment.getName(),
+                treatment.getMinPrice(),
+                treatment.getMaxPrice(),
+                treatment.getDurationMinutes(),
+                treatment.getDescription(),
+                treatment.getImages().stream()
+                        .map(img -> new TreatmentImageResponse(img.getId(), img.getImageUrl()))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/beautiflow/reservation/repository/ShopRepository.java
+++ b/src/main/java/com/beautiflow/reservation/repository/ShopRepository.java
@@ -1,0 +1,10 @@
+package com.beautiflow.reservation.repository;
+
+import com.beautiflow.shop.domain.Shop;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShopRepository extends JpaRepository<Shop, Long> {
+
+}

--- a/src/main/java/com/beautiflow/reservation/repository/TreatmentRepository.java
+++ b/src/main/java/com/beautiflow/reservation/repository/TreatmentRepository.java
@@ -1,0 +1,16 @@
+package com.beautiflow.reservation.repository;
+
+import com.beautiflow.global.domain.TreatmentCategory;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.treatment.domain.Treatment;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TreatmentRepository extends JpaRepository<Treatment, Long> {
+    List<Treatment> findByShop(Shop shop);
+    List<Treatment> findByShopAndCategory(Shop shop, TreatmentCategory category);
+    Optional<Treatment> findByShopAndId(Shop shop, Long id);
+}

--- a/src/main/java/com/beautiflow/reservation/service/ShopService.java
+++ b/src/main/java/com/beautiflow/reservation/service/ShopService.java
@@ -1,0 +1,67 @@
+package com.beautiflow.reservation.service;
+
+import com.beautiflow.global.common.error.ShopErrorCode;
+import com.beautiflow.global.common.error.TreatmentErrorCode;
+import com.beautiflow.global.domain.TreatmentCategory;
+import com.beautiflow.reservation.converter.ShopConverter;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse.BusinessHourDto;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse.NoticeDto;
+import com.beautiflow.reservation.dto.response.ShopDetailResponse.TreatmentDto;
+import com.beautiflow.reservation.dto.response.TreatmentResponse;
+import com.beautiflow.reservation.repository.ShopRepository;
+import com.beautiflow.reservation.repository.TreatmentRepository;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.treatment.domain.Treatment;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShopService {
+
+    private final ShopRepository shopRepository;
+    private final TreatmentRepository treatmentRepository;
+
+    public ShopDetailResponse getShopDetail(Long shopId) {
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new EntityNotFoundException(ShopErrorCode.SHOP_NOT_FOUND.getMessage()));
+
+        return ShopConverter.toDto(shop);
+    }
+
+    public List<TreatmentResponse> getTreatmentsByShopAndCategory(Long shopId, String category) {
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new EntityNotFoundException(ShopErrorCode.SHOP_NOT_FOUND.getMessage()));
+
+        List<Treatment> treatments;
+
+        if (category == null || category.isEmpty()) {
+            treatments = treatmentRepository.findByShop(shop);
+        } else {
+            TreatmentCategory catEnum = Arrays.stream(TreatmentCategory.values())
+                    .filter(c -> c.name().equalsIgnoreCase(category))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(TreatmentErrorCode.INVALID_TREATMENT_PARAMETER.getMessage()));
+            treatments = treatmentRepository.findByShopAndCategory(shop, catEnum);
+        }
+
+        return treatments.stream()
+                .map(TreatmentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public TreatmentResponse getTreatmentDetail(Long shopId, Long treatmentId) {
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new EntityNotFoundException(ShopErrorCode.SHOP_NOT_FOUND.getMessage()));
+
+        Treatment treatment = treatmentRepository.findByShopAndId(shop, treatmentId)
+                .orElseThrow(() -> new EntityNotFoundException(TreatmentErrorCode.TREATMENT_NOT_FOUND.getMessage()));
+
+        return TreatmentResponse.from(treatment);
+    }
+}

--- a/src/main/java/com/beautiflow/user/domain/UserRole.java
+++ b/src/main/java/com/beautiflow/user/domain/UserRole.java
@@ -32,6 +32,6 @@ public class UserRole {
 	private User user;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
+	@Column(name = "role", insertable = false, updatable = false)
 	private GlobalRole role;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,17 @@
 spring:
   profiles:
     active: local
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+server:
+  port: 8080


### PR DESCRIPTION
## 🛰️ Issue Number
#17 
## 🪐 작업 내용
- [고객_매장] 매장 정보 조회 API 개발  
  - GET /shops/{shopId}
-  [고객_매장] 매장 내 시술 목록 조회 API 개발 (카테고리별 필터링) 
   - GET /shops/{shopId}/treatments?category={category}
-  [고객_매장] 시술 세부 정보 조회 
   - GET /shops/{shopId}/treatments/{treatmentId}
## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
