### PR TITLE
feat/#20/reservation-month

### DIFF
--- a/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
@@ -1,0 +1,19 @@
+package com.beautiflow.global.common.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReservationErrorCode implements ErrorCode{
+
+  RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION400", "예약을 찾을 수 없습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+
+}

--- a/src/main/java/com/beautiflow/global/domain/ReservationStatus.java
+++ b/src/main/java/com/beautiflow/global/domain/ReservationStatus.java
@@ -1,3 +1,9 @@
 package com.beautiflow.global.domain;
 
-public enum ReservationStatus { PENDING, CONFIRMED, CANCELLED }
+public enum ReservationStatus {
+  PENDING,       // 확정대기
+  CONFIRMED,     // 예약 확정
+  CANCELLED,     // 취소
+  NO_SHOW,       // 노쇼
+  COMPLETED      // 시술 완료
+}

--- a/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
+++ b/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
@@ -1,0 +1,32 @@
+package com.beautiflow.reservation.controller;
+
+import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.reservation.dto.ReservationMonthRes;
+import com.beautiflow.reservation.service.ReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+  private final ReservationService reservationService;
+
+  @GetMapping("/months") // 사장님 예약 월별 조회
+  @Operation(summary = "월별 예약 유무 조회", description = "특정 월에 예약된 날짜별 예약 개수를 조회합니다.")
+  public ResponseEntity<ApiResponse<List<ReservationMonthRes>>> getReservedDates(
+      @RequestParam Long designerId,
+      @RequestParam String month
+  ) {
+    List<ReservationMonthRes> result = reservationService.getReservedDates(designerId, month);
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+
+}

--- a/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
+++ b/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
@@ -4,22 +4,21 @@ import com.beautiflow.global.common.ApiResponse;
 import com.beautiflow.reservation.dto.ReservationMonthRes;
 import com.beautiflow.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/reservations")
 @RequiredArgsConstructor
+@Tag(name = "Reservation", description = "사장님 월별 예약 조회 API")
 public class ReservationController {
 
   private final ReservationService reservationService;
 
-  @GetMapping("/months") // 사장님 예약 월별 조회
+  @GetMapping("/months")
   @Operation(summary = "월별 예약 유무 조회", description = "특정 월에 예약된 날짜별 예약 개수를 조회합니다.")
   public ResponseEntity<ApiResponse<List<ReservationMonthRes>>> getReservedDates(
       @RequestParam Long designerId,

--- a/src/main/java/com/beautiflow/reservation/dto/ReservationMonthRes.java
+++ b/src/main/java/com/beautiflow/reservation/dto/ReservationMonthRes.java
@@ -1,0 +1,9 @@
+package com.beautiflow.reservation.dto;
+
+import java.time.LocalDate;
+
+public record ReservationMonthRes(
+    LocalDate date,
+    boolean hasReservation,
+    long reservationCount
+) {}

--- a/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
@@ -1,0 +1,22 @@
+package com.beautiflow.reservation.repository;
+
+import com.beautiflow.reservation.domain.Reservation;
+import com.beautiflow.reservation.dto.ReservationMonthRes;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+  @Query("SELECT new com.beautiflow.reservation.dto.ReservationMonthRes(r.reservationDate, true, COUNT(r)) " +
+      "FROM Reservation r " +
+      "WHERE r.designer.id = :designerId " +
+      "AND FUNCTION('DATE_FORMAT', r.reservationDate, '%Y-%m') = :month " +
+      "GROUP BY r.reservationDate")
+  List<ReservationMonthRes> findReservationStatsByDesignerAndMonth(
+      @Param("designerId") Long designerId,
+      @Param("month") String month
+  );
+
+}

--- a/src/main/java/com/beautiflow/reservation/service/ReservationService.java
+++ b/src/main/java/com/beautiflow/reservation/service/ReservationService.java
@@ -1,0 +1,32 @@
+package com.beautiflow.reservation.service;
+
+
+import com.beautiflow.global.common.error.ReservationErrorCode;
+import com.beautiflow.global.common.exception.BeautiFlowException;
+import com.beautiflow.reservation.dto.ReservationMonthRes;
+import com.beautiflow.reservation.repository.ReservationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationService {
+
+  private final ReservationRepository reservationRepository;
+
+  @Transactional(readOnly = true)
+  public List<ReservationMonthRes> getReservedDates(Long designerId, String month) {
+    List<ReservationMonthRes> stats = reservationRepository.findReservationStatsByDesignerAndMonth(designerId, month);
+
+    if (stats.isEmpty()) {
+      throw new BeautiFlowException(ReservationErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    return stats;
+  }
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#20

## 🪐 작업 내용
-날짜별 예약 유무 캘린더 조회

디자이너 ID와 월(yyyy-MM) 파라미터를 받아 해당 디자이너의 예약이 존재하는 날짜만 리스트로 반환합니다.
나중의 확장성을 고려하여 dto를 따로 제작하였고, 예약이 없는 경우 ReservationErrorCode로 넘어가 Reservation 400에러코드를 내보냅니다.

## 📚 Reference

## ✅ Check List
- [✅ ] 코드가 정상적으로 컴파일되나요?
- [ ✅] 테스트 코드를 통과했나요?
- [✅ ] merge할 브랜치의 위치를 확인했나요?
- [✅ ] Label을 지정했나요?
