### PR TITLE
[FEAT] 예약 상세 조회 및 상태 변경 시 고객 자동 등록 기능 구현

### DIFF
--- a/src/main/java/com/beautiflow/customer/domain/DesignerCustomer.java
+++ b/src/main/java/com/beautiflow/customer/domain/DesignerCustomer.java
@@ -1,0 +1,30 @@
+package com.beautiflow.customer.domain;
+
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "designer_customers")
+public class DesignerCustomer {
+
+  @EmbeddedId
+  private DesignerCustomerId id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("designerId")
+  private User designer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("userId")
+  private User customer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("shopId")
+  private Shop shop;
+}

--- a/src/main/java/com/beautiflow/customer/domain/DesignerCustomerId.java
+++ b/src/main/java/com/beautiflow/customer/domain/DesignerCustomerId.java
@@ -1,0 +1,17 @@
+package com.beautiflow.customer.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Embeddable
+public class DesignerCustomerId implements Serializable {
+  private Long designerId;
+  private Long userId;
+  private Long shopId;
+}

--- a/src/main/java/com/beautiflow/customer/dto/CustomerListRes.java
+++ b/src/main/java/com/beautiflow/customer/dto/CustomerListRes.java
@@ -1,0 +1,17 @@
+package com.beautiflow.customer.dto;
+
+import com.beautiflow.user.domain.User;
+
+public record CustomerListRes(
+    Long customerId,
+    String name,
+    String contact // 변경된 필드명 반영
+) {
+  public static CustomerListRes from(User customer) {
+    return new CustomerListRes(
+        customer.getId(),
+        customer.getName(),
+        customer.getContact()
+    );
+  }
+}

--- a/src/main/java/com/beautiflow/customer/repository/DesignerCustomerRepository.java
+++ b/src/main/java/com/beautiflow/customer/repository/DesignerCustomerRepository.java
@@ -1,0 +1,10 @@
+package com.beautiflow.customer.repository;
+
+import com.beautiflow.customer.domain.DesignerCustomer;
+import com.beautiflow.customer.domain.DesignerCustomerId;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DesignerCustomerRepository extends JpaRepository<DesignerCustomer, DesignerCustomerId> {
+  List<DesignerCustomer> findByDesignerId(Long designerId);
+}

--- a/src/main/java/com/beautiflow/customer/service/DesignerCustomerService.java
+++ b/src/main/java/com/beautiflow/customer/service/DesignerCustomerService.java
@@ -1,0 +1,43 @@
+package com.beautiflow.customer.service;
+
+import com.beautiflow.customer.domain.*;
+import com.beautiflow.customer.dto.CustomerListRes;
+import com.beautiflow.customer.repository.DesignerCustomerRepository;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DesignerCustomerService {
+
+  private final DesignerCustomerRepository designerCustomerRepository;
+
+  @Transactional
+  public void autoRegister(User designer, User customer, Shop shop) {
+    DesignerCustomerId id = new DesignerCustomerId(designer.getId(), customer.getId(), shop.getId());
+
+    if (!designerCustomerRepository.existsById(id)) {
+      DesignerCustomer entity = DesignerCustomer.builder()
+          .id(id)
+          .designer(designer)
+          .customer(customer)
+          .shop(shop)
+          .build();
+      designerCustomerRepository.save(entity);
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public List<CustomerListRes> getCustomersByDesigner(Long designerId) {
+    return designerCustomerRepository.findByDesignerId(designerId).stream()
+        .map(dc -> CustomerListRes.from(dc.getCustomer()))
+        .toList();
+  }
+
+
+
+}

--- a/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum ReservationErrorCode implements ErrorCode{
 
   RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION400", "예약을 찾을 수 없습니다."),
-  RESERVATION_TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION401", "지정된 날짜의 예약을 찾을 수 없습니다.");
+  RESERVATION_TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION401", "지정된 날짜의 예약을 찾을 수 없습니다."),
+  RESERVATION_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION402", "세부내역을 찾을 수 없습니다."),
+  RESERVATION_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION403", "예약상태를 확인할 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReservationErrorCode implements ErrorCode{
 
-  RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION400", "예약을 찾을 수 없습니다.");
+  RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION400", "예약을 찾을 수 없습니다."),
+  RESERVATION_TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION401", "지정된 날짜의 예약을 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ReservationErrorCode.java
@@ -1,0 +1,19 @@
+package com.beautiflow.global.common.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReservationErrorCode implements ErrorCode{
+
+  RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION400", "예약을 찾을 수 없습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+
+}

--- a/src/main/java/com/beautiflow/global/domain/ReservationStatus.java
+++ b/src/main/java/com/beautiflow/global/domain/ReservationStatus.java
@@ -1,3 +1,9 @@
 package com.beautiflow.global.domain;
 
-public enum ReservationStatus { PENDING, CONFIRMED, CANCELLED }
+public enum ReservationStatus {
+  PENDING,       // 확정대기
+  CONFIRMED,     // 예약 확정
+  CANCELLED,     // 취소
+  NO_SHOW,       // 노쇼
+  COMPLETED      // 시술 완료
+}

--- a/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
+++ b/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
@@ -1,0 +1,32 @@
+package com.beautiflow.reservation.controller;
+
+import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.reservation.dto.ReservationMonthRes;
+import com.beautiflow.reservation.service.ReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+  private final ReservationService reservationService;
+
+  @GetMapping("/months") // 사장님 예약 월별 조회
+  @Operation(summary = "월별 예약 유무 조회", description = "특정 월에 예약된 날짜별 예약 개수를 조회합니다.")
+  public ResponseEntity<ApiResponse<List<ReservationMonthRes>>> getReservedDates(
+      @RequestParam Long designerId,
+      @RequestParam String month
+  ) {
+    List<ReservationMonthRes> result = reservationService.getReservedDates(designerId, month);
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+
+}

--- a/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
+++ b/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
@@ -1,8 +1,14 @@
 package com.beautiflow.reservation.controller;
 
+import com.beautiflow.customer.dto.CustomerListRes;
+import com.beautiflow.customer.service.DesignerCustomerService;
 import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.reservation.domain.Reservation;
+import com.beautiflow.reservation.dto.ReservationDetailRes;
 import com.beautiflow.reservation.dto.ReservationMonthRes;
 import com.beautiflow.reservation.dto.TimeSlotResponse;
+import com.beautiflow.reservation.dto.UpdateReservationStatusReq;
+import com.beautiflow.reservation.dto.UpdateReservationStatusRes;
 import com.beautiflow.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReservationController {
 
   private final ReservationService reservationService;
+  private final DesignerCustomerService designerCustomerService;
 
   @GetMapping("/months")
   @Operation(summary = "월별 예약 유무 조회", description = "특정 월에 예약된 날짜별 예약 개수를 조회합니다.")
@@ -40,5 +47,38 @@ public class ReservationController {
     List<TimeSlotResponse> result = reservationService.getReservedTimeSlots(designerId, date);
     return ResponseEntity.ok(ApiResponse.success(result));
   }
+
+  @GetMapping("/{reservationId}") // 예약 상세 조회
+  @Operation(summary = "예약 상세 정보 조회")
+  public ResponseEntity<ApiResponse<ReservationDetailRes>> getReservationDetail(
+      @PathVariable Long reservationId
+  ) {
+    ReservationDetailRes result = reservationService.getReservationDetail(reservationId);
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+
+  @PatchMapping("/{reservationId}/status")
+  @Operation(summary = "예약 상태 변경 및 결과 반환")
+  public ResponseEntity<ApiResponse<UpdateReservationStatusRes>> updateReservationStatus(
+      @PathVariable Long reservationId,
+      @RequestBody UpdateReservationStatusReq request
+  ) {
+    reservationService.updateStatus(reservationId, request.status());
+
+    Reservation reservation = reservationService.getReservationEntity(reservationId); // 상태만 확인용
+    UpdateReservationStatusRes response = UpdateReservationStatusRes.from(reservation);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+
+  @GetMapping("/list")
+  @Operation(summary = "디자이너 고객 리스트 조회")
+  public ResponseEntity<ApiResponse<List<CustomerListRes>>> getCustomersByDesigner(
+      @RequestParam Long designerId
+  ) {
+    List<CustomerListRes> customers = designerCustomerService.getCustomersByDesigner(designerId);
+    return ResponseEntity.ok(ApiResponse.success(customers));
+  }
+
 
 }

--- a/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
+++ b/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
@@ -4,22 +4,21 @@ import com.beautiflow.global.common.ApiResponse;
 import com.beautiflow.reservation.dto.ReservationMonthRes;
 import com.beautiflow.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/reservations")
 @RequiredArgsConstructor
+@Tag(name = "Reservation", description = "사장님 월별 예약 조회 API")
 public class ReservationController {
 
   private final ReservationService reservationService;
 
-  @GetMapping("/months") // 사장님 예약 월별 조회
+  @GetMapping("/months")
   @Operation(summary = "월별 예약 유무 조회", description = "특정 월에 예약된 날짜별 예약 개수를 조회합니다.")
   public ResponseEntity<ApiResponse<List<ReservationMonthRes>>> getReservedDates(
       @RequestParam Long designerId,

--- a/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
+++ b/src/main/java/com/beautiflow/reservation/controller/ReservationController.java
@@ -2,11 +2,14 @@ package com.beautiflow.reservation.controller;
 
 import com.beautiflow.global.common.ApiResponse;
 import com.beautiflow.reservation.dto.ReservationMonthRes;
+import com.beautiflow.reservation.dto.TimeSlotResponse;
 import com.beautiflow.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,6 +28,16 @@ public class ReservationController {
       @RequestParam String month
   ) {
     List<ReservationMonthRes> result = reservationService.getReservedDates(designerId, month);
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+
+  @GetMapping("/timeslots") // 시간대별 예약 현황 조회
+  @Operation(summary = "시간대별 예약 현황 조회")
+  public ResponseEntity<ApiResponse<List<TimeSlotResponse>>> getReservedTimeSlots(
+      @RequestParam Long designerId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+  ) {
+    List<TimeSlotResponse> result = reservationService.getReservedTimeSlots(designerId, date);
     return ResponseEntity.ok(ApiResponse.success(result));
   }
 

--- a/src/main/java/com/beautiflow/reservation/domain/Reservation.java
+++ b/src/main/java/com/beautiflow/reservation/domain/Reservation.java
@@ -58,6 +58,11 @@ public class Reservation extends BaseTimeEntity {
 
 	private String requestNotes;
 
+	public void updateStatus(ReservationStatus newStatus) {
+		this.status = newStatus;
+	}
+
+
 	@Column(columnDefinition = "json")
 	private String styleImageUrls;
 

--- a/src/main/java/com/beautiflow/reservation/dto/ReservationDetailRes.java
+++ b/src/main/java/com/beautiflow/reservation/dto/ReservationDetailRes.java
@@ -1,0 +1,27 @@
+package com.beautiflow.reservation.dto;
+
+import com.beautiflow.reservation.domain.Reservation;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ReservationDetailRes(
+    Long reservationId,
+    Long designerId,
+    String customerName,
+    LocalDate date,
+    LocalTime startTime,
+    LocalTime endTime,
+    String status
+) {
+  public static ReservationDetailRes from(Reservation reservation) {
+    return new ReservationDetailRes(
+        reservation.getId(),
+        reservation.getDesigner() != null ? reservation.getDesigner().getId() : null,
+        reservation.getCustomer() != null ? reservation.getCustomer().getName() : null,
+        reservation.getReservationDate(),
+        reservation.getStartTime(),
+        reservation.getEndTime(),
+        reservation.getStatus() != null ? reservation.getStatus().name() : null
+    );
+  }
+}

--- a/src/main/java/com/beautiflow/reservation/dto/ReservationMonthRes.java
+++ b/src/main/java/com/beautiflow/reservation/dto/ReservationMonthRes.java
@@ -1,0 +1,9 @@
+package com.beautiflow.reservation.dto;
+
+import java.time.LocalDate;
+
+public record ReservationMonthRes(
+    LocalDate date,
+    boolean hasReservation,
+    long reservationCount
+) {}

--- a/src/main/java/com/beautiflow/reservation/dto/TimeSlotResponse.java
+++ b/src/main/java/com/beautiflow/reservation/dto/TimeSlotResponse.java
@@ -1,0 +1,11 @@
+package com.beautiflow.reservation.dto;
+
+import java.time.LocalTime;
+
+public record TimeSlotResponse(
+    Long reservationId,
+    String customerName,
+    String status,
+    LocalTime startTime,
+    LocalTime endTime
+) {}

--- a/src/main/java/com/beautiflow/reservation/dto/UpdateReservationStatusReq.java
+++ b/src/main/java/com/beautiflow/reservation/dto/UpdateReservationStatusReq.java
@@ -1,0 +1,9 @@
+package com.beautiflow.reservation.dto;
+
+import com.beautiflow.global.domain.ReservationStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateReservationStatusReq(
+    @NotNull(message = "예약 상태는 필수입니다.")
+    ReservationStatus status
+) {}

--- a/src/main/java/com/beautiflow/reservation/dto/UpdateReservationStatusRes.java
+++ b/src/main/java/com/beautiflow/reservation/dto/UpdateReservationStatusRes.java
@@ -1,0 +1,27 @@
+package com.beautiflow.reservation.dto;
+
+import com.beautiflow.global.domain.ReservationStatus;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UpdateReservationStatusRes(
+    Long reservationId,
+    Long designerId,
+    String customerName,
+    LocalDate date,
+    LocalTime startTime,
+    LocalTime endTime,
+    ReservationStatus status
+) {
+  public static UpdateReservationStatusRes from(com.beautiflow.reservation.domain.Reservation reservation) {
+    return new UpdateReservationStatusRes(
+        reservation.getId(),
+        reservation.getDesigner().getId(),
+        reservation.getCustomer().getName(),
+        reservation.getReservationDate(),
+        reservation.getStartTime(),
+        reservation.getEndTime(),
+        reservation.getStatus()
+    );
+  }
+}

--- a/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
@@ -1,0 +1,22 @@
+package com.beautiflow.reservation.repository;
+
+import com.beautiflow.reservation.domain.Reservation;
+import com.beautiflow.reservation.dto.ReservationMonthRes;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+  @Query("SELECT new com.beautiflow.reservation.dto.ReservationMonthRes(r.reservationDate, true, COUNT(r)) " +
+      "FROM Reservation r " +
+      "WHERE r.designer.id = :designerId " +
+      "AND FUNCTION('DATE_FORMAT', r.reservationDate, '%Y-%m') = :month " +
+      "GROUP BY r.reservationDate")
+  List<ReservationMonthRes> findReservationStatsByDesignerAndMonth(
+      @Param("designerId") Long designerId,
+      @Param("month") String month
+  );
+
+}

--- a/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.beautiflow.reservation.repository;
 
 import com.beautiflow.reservation.domain.Reservation;
 import com.beautiflow.reservation.dto.ReservationMonthRes;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,5 +19,16 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
       @Param("designerId") Long designerId,
       @Param("month") String month
   );
+
+  //시간대별 예약 조회
+  @Query("SELECT r.id, r.customer.name, r.status, r.startTime, r.endTime " +
+      "FROM Reservation r " +
+      "WHERE r.designer.id = :designerId " +
+      "AND r.reservationDate = :date")
+  List<Object[]> findTimeSlotsByDesignerIdAndDate(
+      @Param("designerId") Long designerId,
+      @Param("date") LocalDate date
+  );
+
 
 }

--- a/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/beautiflow/reservation/repository/ReservationRepository.java
@@ -4,6 +4,7 @@ import com.beautiflow.reservation.domain.Reservation;
 import com.beautiflow.reservation.dto.ReservationMonthRes;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,6 +30,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
       @Param("designerId") Long designerId,
       @Param("date") LocalDate date
   );
+
+  @Query("SELECT r FROM Reservation r " + //예약 상세 조회
+      "JOIN FETCH r.designer " +
+      "JOIN FETCH r.customer " +
+      "WHERE r.id = :id")
+  Optional<Reservation> findFetchAllById(@Param("id") Long id);
 
 
 }

--- a/src/main/java/com/beautiflow/reservation/service/ReservationService.java
+++ b/src/main/java/com/beautiflow/reservation/service/ReservationService.java
@@ -4,7 +4,10 @@ package com.beautiflow.reservation.service;
 import com.beautiflow.global.common.error.ReservationErrorCode;
 import com.beautiflow.global.common.exception.BeautiFlowException;
 import com.beautiflow.reservation.dto.ReservationMonthRes;
+import com.beautiflow.reservation.dto.TimeSlotResponse;
 import com.beautiflow.reservation.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,5 +31,25 @@ public class ReservationService {
 
     return stats;
   }
+
+  @Transactional(readOnly = true) // 시간대별 예약 현황 조회
+  public List<TimeSlotResponse> getReservedTimeSlots(Long designerId, LocalDate date) {
+    List<Object[]> results = reservationRepository.findTimeSlotsByDesignerIdAndDate(designerId, date);
+    if (results.isEmpty()) {
+      throw new BeautiFlowException(ReservationErrorCode.RESERVATION_TIME_NOT_FOUND);
+    }
+    return results.stream()
+        .map(row -> new TimeSlotResponse(
+            (Long) row[0],                 // reservationId
+            (String) row[1],               // customerName
+            row[2].toString(),             // status (enum → string)
+            (LocalTime) row[3],            // startTime
+            (LocalTime) row[4]             // endTime
+        ))
+        .toList();
+  }
+
+
+
 
 }

--- a/src/main/java/com/beautiflow/reservation/service/ReservationService.java
+++ b/src/main/java/com/beautiflow/reservation/service/ReservationService.java
@@ -1,0 +1,32 @@
+package com.beautiflow.reservation.service;
+
+
+import com.beautiflow.global.common.error.ReservationErrorCode;
+import com.beautiflow.global.common.exception.BeautiFlowException;
+import com.beautiflow.reservation.dto.ReservationMonthRes;
+import com.beautiflow.reservation.repository.ReservationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationService {
+
+  private final ReservationRepository reservationRepository;
+
+  @Transactional(readOnly = true)
+  public List<ReservationMonthRes> getReservedDates(Long designerId, String month) {
+    List<ReservationMonthRes> stats = reservationRepository.findReservationStatsByDesignerAndMonth(designerId, month);
+
+    if (stats.isEmpty()) {
+      throw new BeautiFlowException(ReservationErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    return stats;
+  }
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#25
## 🪐 작업 내용
예약 상세 조회 API 구현

GET /reservations/{reservationId}

예약 상태가 CONFIRMED이고 종료 시간이 지난 경우, 자동으로 COMPLETED로 변경됨

상태 변경 시 DB에 즉시 반영됨

예약 상태 변경 API 구현

PATCH /reservations/{reservationId}/status

예약 상태를 클라이언트 요청에 따라 변경

상태가 CONFIRMED일 경우 고객 자동 등록 진행

고객 자동 등록 기능 구현

designer_customer 테이블 사용

동일한 고객-디자이너-샵 조합이 없을 경우에만 신규 등록

중복 등록 방지

디자이너 고객 리스트 조회 API 추가

GET /reservations/list?designerId=...

디자이너 기준 고객 리스트 반환 (Customer의 이름, 연락처 포함)

예약 상태 변경 응답 DTO 추가

상태 변경 후 변경된 예약 정보를 반환하기 위한 DTO UpdateReservationStatusRes 생성

추가적으로 참고할 사항
designer_customer는 복합키(designerId, userId, shopId)로 설계됨
Swagger 문서화 완료
## 📚 Reference

## ✅ Check List
- [✅ ] 코드가 정상적으로 컴파일되나요?
- [✅ ] 테스트 코드를 통과했나요?
- [✅ ] merge할 브랜치의 위치를 확인했나요?
- [✅ ] Label을 지정했나요?
