### PR TITLE
[FEAT] 매장 공지사항 crud 구현

### DIFF
--- a/src/main/java/com/beautiflow/global/common/error/ShopErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ShopErrorCode.java
@@ -11,7 +11,9 @@ public enum ShopErrorCode implements ErrorCode{
     SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404", "매장을 찾을 수 없습니다."),
     INVALID_SHOP_PARAMETER(HttpStatus.BAD_REQUEST, "SHOP400", "유효하지 않은 매장 파라미터입니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당 이미지를 찾을 수 없습니다."),
-    UNAUTHORIZED_SHOP_ACCESS(HttpStatus.FORBIDDEN, "SHOP403", "해당 매장에 접근할 수 있는 권한이 없습니다.");
+    UNAUTHORIZED_SHOP_ACCESS(HttpStatus.FORBIDDEN, "SHOP403", "해당 매장에 접근할 수 있는 권한이 없습니다."),
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE404", "공지사항을 찾을 수 없습니다."),
+    FORBIDDEN_NOTICE_ACCESS(HttpStatus.FORBIDDEN, "NOTICE403", "공지사항에 접근할 수 있는 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/beautiflow/shop/controller/ShopNoticeController.java
+++ b/src/main/java/com/beautiflow/shop/controller/ShopNoticeController.java
@@ -1,0 +1,76 @@
+package com.beautiflow.shop.controller;
+
+import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.shop.domain.ShopNotice;
+import com.beautiflow.shop.dto.NoticeCreateReq;
+import com.beautiflow.shop.dto.NoticeUpdateReq;
+import com.beautiflow.shop.dto.ShopNoticeRes;
+import com.beautiflow.shop.service.ShopNoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/shops/{shopId}/notices")
+public class ShopNoticeController {
+
+  private final ShopNoticeService shopNoticeService;
+
+  // 매장 공지사항 조회
+  @Operation(summary = "매장 공지사항 조회")
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<ShopNoticeRes>>> getNotices(
+      @PathVariable Long shopId
+  ) {
+    List<ShopNoticeRes> notices = shopNoticeService.getNotices(shopId);
+    return ResponseEntity.ok(ApiResponse.success(notices));
+  }
+
+  // 매장 공지사항 등록
+  @Operation(summary = "매장 공지사항 등록")
+  @PostMapping
+  public ResponseEntity<ApiResponse<ShopNotice>> createNotice(
+      @PathVariable Long shopId,
+      @RequestBody NoticeCreateReq requestDto
+  ) {
+    ShopNotice createdNotice = shopNoticeService.createNotice(shopId, requestDto);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(createdNotice));
+  }
+
+  // 매장 공지사항 수정
+  @Operation(summary = "매장 공지사항 수정")
+  @PatchMapping("/{noticeId}")
+  public ResponseEntity<ApiResponse<ShopNotice>> updateNotice(
+      @PathVariable Long shopId,
+      @PathVariable Long noticeId,
+      @RequestBody NoticeUpdateReq requestDto
+  ) {
+    ShopNotice updatedNotice = shopNoticeService.updateNotice(shopId, noticeId, requestDto);
+    return ResponseEntity.ok(ApiResponse.success(updatedNotice));
+  }
+
+  // 매장 공지사항 삭제
+  @Operation(summary = "매장 공지사항 삭제")
+  @DeleteMapping("/{noticeId}")
+  public ResponseEntity<ApiResponse<Void>> deleteNotice(
+      @PathVariable Long shopId,
+      @PathVariable Long noticeId
+  ) {
+    shopNoticeService.deleteNotice(shopId, noticeId);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+
+}

--- a/src/main/java/com/beautiflow/shop/domain/ShopNotice.java
+++ b/src/main/java/com/beautiflow/shop/domain/ShopNotice.java
@@ -1,10 +1,13 @@
 package com.beautiflow.shop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -24,9 +27,30 @@ public class ShopNotice {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(nullable = false, length = 50)
+	private String title;
+
+	@Column(nullable = false, length = 500)
+	private String content;
+
+	@JsonIgnore
 	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "shop_id", nullable = false)
 	private Shop shop;
 
-	private String title;
-	private String content;
+	@Builder
+	public ShopNotice(String title, String content, Shop shop) {
+		this.title = title;
+		this.content = content;
+		this.shop = shop;
+	}
+
+	public void update(String title, String content) {
+		if (title != null) {
+			this.title = title;
+		}
+		if (content != null) {
+			this.content = content;
+		}
+	}
 }

--- a/src/main/java/com/beautiflow/shop/dto/NoticeCreateReq.java
+++ b/src/main/java/com/beautiflow/shop/dto/NoticeCreateReq.java
@@ -1,0 +1,7 @@
+package com.beautiflow.shop.dto;
+
+public record NoticeCreateReq(
+    String title,
+    String content
+) {
+}

--- a/src/main/java/com/beautiflow/shop/dto/NoticeUpdateReq.java
+++ b/src/main/java/com/beautiflow/shop/dto/NoticeUpdateReq.java
@@ -1,0 +1,7 @@
+package com.beautiflow.shop.dto;
+
+public record NoticeUpdateReq(
+    String title,
+    String content
+) {
+}

--- a/src/main/java/com/beautiflow/shop/dto/ShopNoticeRes.java
+++ b/src/main/java/com/beautiflow/shop/dto/ShopNoticeRes.java
@@ -1,0 +1,17 @@
+package com.beautiflow.shop.dto;
+
+import com.beautiflow.shop.domain.ShopNotice;
+import lombok.Getter;
+
+@Getter
+public class ShopNoticeRes {
+  private final Long noticeId;
+  private final String title;
+  private final String content;
+
+  public ShopNoticeRes(ShopNotice notice) {
+    this.noticeId = notice.getId();
+    this.title = notice.getTitle();
+    this.content = notice.getContent();
+  }
+}

--- a/src/main/java/com/beautiflow/shop/repository/ShopNoticeRepository.java
+++ b/src/main/java/com/beautiflow/shop/repository/ShopNoticeRepository.java
@@ -1,0 +1,7 @@
+package com.beautiflow.shop.repository;
+
+import com.beautiflow.shop.domain.ShopNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopNoticeRepository extends JpaRepository<ShopNotice, Long> {
+}

--- a/src/main/java/com/beautiflow/shop/service/ShopNoticeService.java
+++ b/src/main/java/com/beautiflow/shop/service/ShopNoticeService.java
@@ -1,0 +1,82 @@
+package com.beautiflow.shop.service;
+
+import com.beautiflow.global.common.error.ShopErrorCode;
+import com.beautiflow.global.common.exception.BeautiFlowException;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.shop.domain.ShopNotice;
+import com.beautiflow.shop.dto.NoticeCreateReq;
+import com.beautiflow.shop.dto.NoticeUpdateReq;
+import com.beautiflow.shop.dto.ShopNoticeRes;
+import com.beautiflow.shop.repository.ShopNoticeRepository;
+import com.beautiflow.shop.repository.ShopRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ShopNoticeService {
+
+  private final ShopRepository shopRepository;
+  private final ShopNoticeRepository shopNoticeRepository;
+
+  @Transactional(readOnly = true)
+  public List<ShopNoticeRes> getNotices(Long shopId) {
+    Shop shop = shopRepository.findById(shopId)
+        .orElseThrow(() -> new BeautiFlowException(ShopErrorCode.SHOP_NOT_FOUND));
+
+    return shop.getNotices().stream()
+        .map(ShopNoticeRes::new)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public ShopNotice createNotice(Long shopId, NoticeCreateReq requestDto) {
+    Shop shop = shopRepository.findById(shopId)
+        .orElseThrow(() -> new BeautiFlowException(ShopErrorCode.SHOP_NOT_FOUND));
+
+    ShopNotice notice = ShopNotice.builder()
+        .title(requestDto.title())
+        .content(requestDto.content())
+        .shop(shop)
+        .build();
+
+    return shopNoticeRepository.save(notice);
+  }
+
+  @Transactional
+  public ShopNotice updateNotice(Long shopId, Long noticeId, NoticeUpdateReq requestDto) {
+    if (!shopRepository.existsById(shopId)) {
+      throw new BeautiFlowException(ShopErrorCode.SHOP_NOT_FOUND);
+    }
+
+    ShopNotice notice = shopNoticeRepository.findById(noticeId)
+        .orElseThrow(() -> new BeautiFlowException(ShopErrorCode.NOTICE_NOT_FOUND));
+
+    if (!notice.getShop().getId().equals(shopId)) {
+      throw new BeautiFlowException(ShopErrorCode.FORBIDDEN_NOTICE_ACCESS);
+    }
+
+    notice.update(requestDto.title(), requestDto.content());
+
+    return notice;
+  }
+
+  @Transactional
+  public void deleteNotice(Long shopId, Long noticeId) {
+    if (!shopRepository.existsById(shopId)) {
+      throw new BeautiFlowException(ShopErrorCode.SHOP_NOT_FOUND);
+    }
+
+    ShopNotice notice = shopNoticeRepository.findById(noticeId)
+        .orElseThrow(() -> new BeautiFlowException(ShopErrorCode.NOTICE_NOT_FOUND));
+
+    if (!notice.getShop().getId().equals(shopId)) {
+      throw new BeautiFlowException(ShopErrorCode.FORBIDDEN_NOTICE_ACCESS);
+    }
+
+    shopNoticeRepository.delete(notice);
+  }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
39

## 🪐 작업 내용
- 매장 공지사항 조회, 등록, 수정, 삭제 api 구현

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
