### PR TITLE
[FEAT] 샵 등록, 입사신청 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 	implementation 'software.amazon.awssdk:s3'
 
+	//aop
+	implementation("org.springframework.boot:spring-boot-starter-aop")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/beautiflow/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/beautiflow/global/common/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/","/users/signup").permitAll()
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated())
 
                 .sessionManagement(

--- a/src/main/java/com/beautiflow/global/common/config/SwaggerConfig.java
+++ b/src/main/java/com/beautiflow/global/common/config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.beautiflow.global.common.config;
 
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,10 +13,22 @@ public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI customOpenAPI() {
+
+		SecurityScheme securityScheme = new SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.scheme("bearer")
+				.bearerFormat("JWT")
+				.in(SecurityScheme.In.HEADER)
+				.name("Authorization");
+
+		SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
+
 		return new OpenAPI()
 			.info(new Info()
 				.title("BeautiFlow API Docs")
 				.version("1.0")
-				.description("BeautiFlow 백엔드 API 명세서입니다."));
+				.description("BeautiFlow 백엔드 API 명세서입니다."))
+				.addSecurityItem(securityRequirement)
+				.schemaRequirement("BearerAuth", securityScheme);
 	}
 }

--- a/src/main/java/com/beautiflow/global/common/error/ShopErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/ShopErrorCode.java
@@ -11,7 +11,11 @@ public enum ShopErrorCode implements ErrorCode{
     SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP404", "매장을 찾을 수 없습니다."),
     INVALID_SHOP_PARAMETER(HttpStatus.BAD_REQUEST, "SHOP400", "유효하지 않은 매장 파라미터입니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당 이미지를 찾을 수 없습니다."),
-    UNAUTHORIZED_SHOP_ACCESS(HttpStatus.FORBIDDEN, "SHOP403", "해당 매장에 접근할 수 있는 권한이 없습니다.");
+    UNAUTHORIZED_SHOP_ACCESS(HttpStatus.FORBIDDEN, "SHOP403", "해당 매장에 접근할 수 있는 권한이 없습니다."),
+    SHOP_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "SHOP405", "이미 등록된 매장입니다."),
+    ALREADY_SHOP_MEMBER(HttpStatus.BAD_REQUEST,"SHOP406","이미 해당 매장의 직원으로 등록되어 있습니다."),
+    ACCESS_DENIED_SHOP_ROLE(HttpStatus.BAD_REQUEST,"SHOP407", "원장만 가능한 기능입니다."),
+    SHOP_MEMBER_NOT_APPROVED(HttpStatus.BAD_REQUEST,"SHOP408","아직 승인되지 않은 직원입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/beautiflow/global/common/security/CustomOAuth2User.java
+++ b/src/main/java/com/beautiflow/global/common/security/CustomOAuth2User.java
@@ -16,6 +16,7 @@ public class CustomOAuth2User implements OAuth2User {
     private final String provider;
     @Getter
     private final String kakaoId;
+    @Getter
     private final Long userId;
     private final GlobalRole role;
 

--- a/src/main/java/com/beautiflow/global/common/security/annotation/AuthCheck.java
+++ b/src/main/java/com/beautiflow/global/common/security/annotation/AuthCheck.java
@@ -1,0 +1,15 @@
+package com.beautiflow.global.common.security.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import com.beautiflow.global.domain.ShopRole;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthCheck {
+    ShopRole[] value();
+}

--- a/src/main/java/com/beautiflow/global/common/security/annotation/AuthCheckAspect.java
+++ b/src/main/java/com/beautiflow/global/common/security/annotation/AuthCheckAspect.java
@@ -1,0 +1,94 @@
+package com.beautiflow.global.common.security.annotation;
+
+import com.beautiflow.global.common.error.ShopErrorCode;
+import com.beautiflow.global.common.error.UserErrorCode;
+import com.beautiflow.global.common.exception.BeautiFlowException;
+import com.beautiflow.global.common.security.CustomOAuth2User;
+import com.beautiflow.global.domain.ApprovalStatus;
+import com.beautiflow.shop.domain.ShopMember;
+import com.beautiflow.shop.repository.ShopMemberRepository;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@RequiredArgsConstructor
+@Component
+public class AuthCheckAspect {
+
+    private final ShopMemberRepository shopMemberRepository;
+
+    @Around("@annotation(authCheck)")
+    public Object validateShopRole(ProceedingJoinPoint joinPoint, AuthCheck authCheck) throws Throwable {
+
+        // 현재 인증 정보에서 userId 가져오기
+        Long userId = getCurrentUserId();
+
+        //@PathVariable 기반으로 shopId 추출
+        Long shopId = extractShopId(joinPoint);
+
+        //ShopMember 조회
+        ShopMember shopMember = shopMemberRepository.findByUserIdAndShopId(userId, shopId)
+                .orElseThrow(() -> new BeautiFlowException(ShopErrorCode.UNAUTHORIZED_SHOP_ACCESS));
+
+        // 권한 체크
+        boolean hasRequiredRole = Arrays.stream(authCheck.value())
+                .anyMatch(requiredRole -> requiredRole == shopMember.getRole());
+
+
+        if (shopMember.getStatus().equals(ApprovalStatus.PENDING)) {
+            throw new BeautiFlowException(ShopErrorCode.SHOP_MEMBER_NOT_APPROVED);
+        }
+
+        if (shopMember.getStatus().equals(ApprovalStatus.REJECTED)) {
+            throw new BeautiFlowException(ShopErrorCode.UNAUTHORIZED_SHOP_ACCESS);
+        }
+
+        if (!hasRequiredRole) {
+            throw new BeautiFlowException(ShopErrorCode.ACCESS_DENIED_SHOP_ROLE);
+        }
+
+
+        return joinPoint.proceed();
+    }
+
+    //현재 로그인된 사용자 id 추출
+    private Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new BeautiFlowException(UserErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof CustomOAuth2User customUser) {
+            return customUser.getUserId();
+        }
+
+        throw new BeautiFlowException(UserErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    //파라미터 인자 중 shopId를 찾아 반환
+    private Long extractShopId(ProceedingJoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        String[] parameterNames = methodSignature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+        Parameter[] parameters = methodSignature.getMethod().getParameters();
+
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameterNames[i].equals("shopId") && args[i] instanceof Long) {
+                return (Long) args[i];
+            }
+        }
+
+        throw new BeautiFlowException(ShopErrorCode.SHOP_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/beautiflow/global/common/util/JWTUtil.java
+++ b/src/main/java/com/beautiflow/global/common/util/JWTUtil.java
@@ -11,10 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class JWTUtil {
 
-    private final long accessTokenValidity = 1000L * 60 * 30; // 30분
+    private final long accessTokenValidity = 1000L * 60 * 60; // 1시간
     private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 7; // 7일
-
-
     private SecretKey secretKey;
 
     public JWTUtil(@Value("${spring.jwt.secret}") String secret) {

--- a/src/main/java/com/beautiflow/shop/controller/ShopController.java
+++ b/src/main/java/com/beautiflow/shop/controller/ShopController.java
@@ -1,17 +1,25 @@
 package com.beautiflow.shop.controller;
 
 import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.shop.dto.ShopApplyRes;
 import com.beautiflow.shop.dto.ShopDetailResponse;
+import com.beautiflow.global.common.security.CustomOAuth2User;
 import com.beautiflow.reservation.dto.response.TreatmentDetailWithOptionResponse;
 import com.beautiflow.reservation.dto.response.TreatmentResponse;
 import com.beautiflow.shop.service.ShopService;
+import com.beautiflow.shop.dto.ShopRegistrationReq;
+import com.beautiflow.shop.dto.ShopRegistrationRes;
+import com.beautiflow.shop.service.ShopOnboardingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +31,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class ShopController {
 
     private final ShopService shopService;
+    private final ShopOnboardingService shopOnboardingService;
+
+
 
     @Operation(summary = "매장 정보 조회", description = "shopId로 매장 정보 조회")
     @GetMapping("/{shopId}")
@@ -56,5 +67,25 @@ public class ShopController {
             @PathVariable Long treatmentId) {
         TreatmentDetailWithOptionResponse response = shopService.getTreatmentDetailWithOptions(shopId, treatmentId);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "샵 등록", description = "새로운 샵을 등록하는 API입니다.")
+    @PostMapping
+    public ResponseEntity<ShopRegistrationRes> register(
+            @RequestBody ShopRegistrationReq shopRegistrationReq,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getUserId();
+        ShopRegistrationRes shopRegistrationRes = shopOnboardingService.registerShop(userId, shopRegistrationReq);
+        return ResponseEntity.ok(shopRegistrationRes);
+
+    }
+
+    @Operation(summary = "입사 신청", description = "직원이 샵에 입사를 신청하는 API입니다.")
+    @PostMapping("/{shopId}/apply")
+    public ResponseEntity<ShopApplyRes> applyToShop(@PathVariable Long shopId,
+            @AuthenticationPrincipal CustomOAuth2User currentUser) {
+        Long userId = currentUser.getUserId();
+        ShopApplyRes shopApplyRes = shopOnboardingService.ApplyToShop(userId, shopId);
+        return ResponseEntity.ok(shopApplyRes);
     }
 }

--- a/src/main/java/com/beautiflow/shop/converter/ShopConverter.java
+++ b/src/main/java/com/beautiflow/shop/converter/ShopConverter.java
@@ -1,5 +1,7 @@
 package com.beautiflow.shop.converter;
 
+import com.beautiflow.shop.domain.ShopMember;
+import com.beautiflow.shop.dto.ShopApplyRes;
 import com.beautiflow.shop.dto.ShopDetailResponse;
 import com.beautiflow.shop.dto.ShopDetailResponse.BusinessHourDto;
 import com.beautiflow.shop.dto.ShopDetailResponse.NoticeDto;
@@ -10,6 +12,8 @@ import com.beautiflow.reservation.dto.response.TreatmentDetailWithOptionResponse
 import com.beautiflow.shop.domain.BusinessHour;
 import com.beautiflow.shop.domain.Shop;
 import com.beautiflow.shop.domain.ShopNotice;
+import com.beautiflow.shop.dto.ShopRegistrationRes;
+import com.beautiflow.shop.dto.ShopRegistrationRes.ShopMemberRes;
 import com.beautiflow.treatment.domain.OptionGroup;
 import com.beautiflow.treatment.domain.OptionItem;
 import com.beautiflow.treatment.domain.Treatment;
@@ -115,6 +119,35 @@ public class ShopConverter {
                 .name(item.getName())
                 .extraMinutes(item.getExtraMinutes())
                 .description(item.getDescription())
+                .build();
+    }
+
+    public static ShopRegistrationRes toShopRegistrationRes(Shop shop, ShopMember shopMember) {
+        return ShopRegistrationRes.builder()
+                .id(shop.getId())
+                .name(shop.getShopName())
+                .address(shop.getAddress())
+                .businessRegistrationNumber(shop.getBusinessRegistrationNumber())
+                .shopMember(
+                        ShopMemberRes.builder()
+                                .id(shopMember.getId())
+                                .shopId(shop.getId())
+                                .userId(shopMember.getUser().getId())
+                                .role(shopMember.getRole())
+                                .status(shopMember.getStatus())
+                                .appliedAt(shopMember.getAppliedAt())
+                                .processedAt(shopMember.getProcessedAt())
+                                .build()
+                )
+                .build();
+    }
+
+    public static ShopApplyRes toShopApplyRes(Shop shop, ShopMember shopMember) {
+        return ShopApplyRes.builder()
+                .shopId(shop.getId())
+                .userId(shopMember.getUser().getId())
+                .shopMemberId(shopMember.getId())
+                .status(shopMember.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/beautiflow/shop/dto/ShopApplyRes.java
+++ b/src/main/java/com/beautiflow/shop/dto/ShopApplyRes.java
@@ -1,0 +1,15 @@
+package com.beautiflow.shop.dto;
+
+import com.beautiflow.global.domain.ApprovalStatus;
+import lombok.Builder;
+
+@Builder
+public record ShopApplyRes(
+        ApprovalStatus status,
+        Long shopMemberId,
+        Long userId,
+        Long shopId
+
+        ) {
+
+}

--- a/src/main/java/com/beautiflow/shop/dto/ShopRegistrationReq.java
+++ b/src/main/java/com/beautiflow/shop/dto/ShopRegistrationReq.java
@@ -1,0 +1,9 @@
+package com.beautiflow.shop.dto;
+
+public record ShopRegistrationReq(
+        String name,
+        String address,
+        String businessRegistrationNumber
+) {
+
+}

--- a/src/main/java/com/beautiflow/shop/dto/ShopRegistrationRes.java
+++ b/src/main/java/com/beautiflow/shop/dto/ShopRegistrationRes.java
@@ -1,0 +1,29 @@
+package com.beautiflow.shop.dto;
+
+import com.beautiflow.global.domain.ApprovalStatus;
+import com.beautiflow.global.domain.ShopRole;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ShopRegistrationRes(
+        Long id,
+        String name,
+        String address,
+        String businessRegistrationNumber,
+        ShopRegistrationRes.ShopMemberRes shopMember
+) {
+
+    @Builder
+    public record ShopMemberRes(Long id,
+                                Long shopId,
+                                Long userId,
+                                ShopRole role,
+                                ApprovalStatus status,
+                                LocalDateTime appliedAt,
+                                LocalDateTime processedAt) {
+
+    }
+
+
+}

--- a/src/main/java/com/beautiflow/shop/repository/ShopMemberRepository.java
+++ b/src/main/java/com/beautiflow/shop/repository/ShopMemberRepository.java
@@ -1,0 +1,13 @@
+package com.beautiflow.shop.repository;
+
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.shop.domain.ShopMember;
+import com.beautiflow.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopMemberRepository extends JpaRepository<ShopMember,Long> {
+
+    boolean existsByUserAndShop(User user, Shop shop);
+    Optional<ShopMember> findByUserIdAndShopId(Long userId, Long shopId);
+}

--- a/src/main/java/com/beautiflow/shop/repository/ShopRepository.java
+++ b/src/main/java/com/beautiflow/shop/repository/ShopRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ShopRepository extends JpaRepository<Shop, Long> {
 
+   boolean existsByBusinessRegistrationNumber(String buisnessRegistrationNumber);
 }

--- a/src/main/java/com/beautiflow/shop/service/ShopOnboardingService.java
+++ b/src/main/java/com/beautiflow/shop/service/ShopOnboardingService.java
@@ -1,0 +1,101 @@
+package com.beautiflow.shop.service;
+
+
+import com.beautiflow.global.common.error.ShopErrorCode;
+import com.beautiflow.global.common.error.UserErrorCode;
+import com.beautiflow.global.common.exception.BeautiFlowException;
+import com.beautiflow.global.domain.ApprovalStatus;
+import com.beautiflow.global.domain.ShopRole;
+import com.beautiflow.shop.converter.ShopConverter;
+import com.beautiflow.shop.domain.Shop;
+import com.beautiflow.shop.domain.ShopMember;
+import com.beautiflow.shop.dto.ShopApplyRes;
+import com.beautiflow.shop.dto.ShopRegistrationReq;
+import com.beautiflow.shop.dto.ShopRegistrationRes;
+import com.beautiflow.shop.repository.ShopMemberRepository;
+import com.beautiflow.shop.repository.ShopRepository;
+import com.beautiflow.user.domain.User;
+import com.beautiflow.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ShopOnboardingService {
+
+    private final ShopRepository shopRepository;
+    private final UserRepository userRepository;
+    private final ShopMemberRepository shopMemberRepository;
+
+    public ShopRegistrationRes registerShop(Long userId, ShopRegistrationReq shopRegistrationReq) {
+
+        String name = shopRegistrationReq.name();
+        String address = shopRegistrationReq.address();
+        String businessRegistrationNumber = shopRegistrationReq.businessRegistrationNumber();
+
+        if (shopRepository.existsByBusinessRegistrationNumber(businessRegistrationNumber)) {
+            throw new BeautiFlowException(ShopErrorCode.SHOP_ALREADY_REGISTERED);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BeautiFlowException(UserErrorCode.USER_NOT_FOUND));
+
+
+        Shop shop = Shop.builder()
+                .shopName(name)
+                .address(address)
+                .businessRegistrationNumber(businessRegistrationNumber)
+                .build();
+        shopRepository.save(shop);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        ShopMember shopMember = ShopMember.builder()
+                .shop(shop)
+                .user(user)
+                .role(ShopRole.OWNER)
+                .status(ApprovalStatus.APPROVED)
+                .appliedAt(now)
+                .processedAt(now)
+                .build();
+        shopMemberRepository.save(shopMember);
+
+        return ShopConverter.toShopRegistrationRes(shop, shopMember);
+
+    }
+
+    public ShopApplyRes ApplyToShop(Long userId, Long shopId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BeautiFlowException(UserErrorCode.USER_NOT_FOUND));
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new BeautiFlowException(ShopErrorCode.SHOP_NOT_FOUND));
+
+        boolean isDuplicate = shopMemberRepository.existsByUserAndShop(user, shop);
+        if (isDuplicate) {
+            throw new BeautiFlowException(ShopErrorCode.ALREADY_SHOP_MEMBER);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+
+        ShopMember shopMember = ShopMember.builder()
+                .user(user)
+                .shop(shop)
+                .role(ShopRole.DESIGNER)
+                .status(ApprovalStatus.PENDING)
+                .appliedAt(now)
+                .processedAt(now)
+                .build();
+
+        shopMemberRepository.save(shopMember);
+
+        return ShopConverter.toShopApplyRes(shop, shopMember);
+
+    }
+
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number

#38

## 🪐 작업 내용
- `SecurityConfig` 파일에 Swagger 경로 허용 추가
- `SwaggerConfig`에 JWT 인증 버튼 추가
- AOP 기반 인가 어노테이션 구현  
  → `@AuthCheck({ShopRole.OWNER})` 형태로 컨트롤러에서 사용 가능
- **Shop 등록 API 구현**  
  → 등록 시 `shopMember`에 추가되며, `role`은 `OWNER`, `status`는 `APPROVED`로 설정됨
- **입사 신청 API 구현**  
  → 신청 시 `shopMember`에 추가되며, `role`은 `DESIGNER`, `status`는 `PENDING`으로 설정됨

## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
