### PR TITLE
[REFACT] 로그인 방식 변경

### DIFF
--- a/src/main/java/com/beautiflow/global/common/config/RedisConfig.java
+++ b/src/main/java/com/beautiflow/global/common/config/RedisConfig.java
@@ -99,7 +99,7 @@ public class RedisConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-            .setAddress("redis://" + host + ":" + port);
+            .setAddress("rediss://" + host + ":" + port);
         return Redisson.create(config);
     }
 

--- a/src/main/java/com/beautiflow/global/common/config/RedisConfig.java
+++ b/src/main/java/com/beautiflow/global/common/config/RedisConfig.java
@@ -99,7 +99,7 @@ public class RedisConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-            .setAddress("rediss://" + host + ":" + port);
+            .setAddress("redis://" + host + ":" + port);
         return Redisson.create(config);
     }
 

--- a/src/main/java/com/beautiflow/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/beautiflow/global/common/config/SecurityConfig.java
@@ -68,10 +68,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/",
+                                "/users/login",
                                 "/connect/**",
                                 "/users/auth/phone/send-code",
                                 "/users/auth/phone/verify-code",
-
                                 "/login/oauth2/code/kakao-customer",
                                 "/login/oauth2/code/kakao-staff",
                                 "/users/signup",

--- a/src/main/java/com/beautiflow/global/common/error/UserErrorCode.java
+++ b/src/main/java/com/beautiflow/global/common/error/UserErrorCode.java
@@ -25,7 +25,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_STYLE_NOT_FOUND(HttpStatus.NOT_FOUND,"USER_014","저장된 스타일이 존재하지 않습니다."),
     USER_STYLE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"USER_015","이미 해당 사용자의 스타일이 저장되어 있습니다."),
 	USER_STYLE_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST,"USER_016","요청하신 사용자 스타일 이미지 ID를 찾을 수 없습니다."),
-	USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST,"USER_017","이미 탈퇴한 사용자입니다.");
+	USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST,"USER_017","이미 탈퇴한 사용자입니다."),
+	LOGIN_KEY_REQUIRED(HttpStatus.BAD_REQUEST,"USER_018","로그인 키가 필요합니다.");
 
 
 

--- a/src/main/java/com/beautiflow/global/common/security/authentication/CustomOAuth2UserService.java
+++ b/src/main/java/com/beautiflow/global/common/security/authentication/CustomOAuth2UserService.java
@@ -3,10 +3,12 @@ package com.beautiflow.global.common.security.authentication;
 import com.beautiflow.global.common.error.UserErrorCode;
 import com.beautiflow.global.common.exception.BeautiFlowException;
 import com.beautiflow.global.domain.GlobalRole;
-import com.beautiflow.user.dto.KakaoRes;
+import com.beautiflow.global.common.security.dto.KakaoRes;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +23,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         KakaoRes kakaoRes = KakaoRes.from(oAuth2User.getAttributes(), registrationId);
-
         GlobalRole globalRole = switch (kakaoRes.provider()) {
             case "kakao-customer" -> GlobalRole.CUSTOMER;
             case "kakao-staff" -> GlobalRole.STAFF;

--- a/src/main/java/com/beautiflow/global/common/security/dto/KakaoRes.java
+++ b/src/main/java/com/beautiflow/global/common/security/dto/KakaoRes.java
@@ -1,4 +1,4 @@
-package com.beautiflow.user.dto;
+package com.beautiflow.global.common.security.dto;
 
 import java.util.Map;
 import lombok.Builder;

--- a/src/main/java/com/beautiflow/user/controller/UserController.java
+++ b/src/main/java/com/beautiflow/user/controller/UserController.java
@@ -3,10 +3,13 @@ package com.beautiflow.user.controller;
 import com.beautiflow.global.common.ApiResponse;
 import com.beautiflow.global.common.security.authentication.CustomOAuth2User;
 import com.beautiflow.global.common.ApiResponse;
+import com.beautiflow.user.dto.LoginReq;
+import com.beautiflow.user.dto.LoginRes;
 import com.beautiflow.user.dto.SignUpReq;
 import com.beautiflow.user.dto.SignUpRes;
 import com.beautiflow.user.dto.TokenReq;
 import com.beautiflow.user.dto.TokenRes;
+import com.beautiflow.user.service.LoginService;
 import com.beautiflow.user.service.UserExitService;
 import com.beautiflow.user.service.RefreshService;
 import com.beautiflow.user.dto.UserStylePatchReq;
@@ -38,6 +41,13 @@ public class UserController {
     private final RefreshService refreshService;
     private final UserExitService userExitService;
     private final UserStyleService userStyleService;
+    private final LoginService loginService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginRes>> login(@RequestBody LoginReq loginReq){
+        LoginRes loginRes = loginService.login(loginReq);
+        return ResponseEntity.ok(ApiResponse.success(loginRes));
+    }
 
 
     @PostMapping("/signup")

--- a/src/main/java/com/beautiflow/user/dto/LoginReq.java
+++ b/src/main/java/com/beautiflow/user/dto/LoginReq.java
@@ -1,0 +1,7 @@
+package com.beautiflow.user.dto;
+
+public record LoginReq (
+        String loginKey
+){
+
+}

--- a/src/main/java/com/beautiflow/user/dto/LoginRes.java
+++ b/src/main/java/com/beautiflow/user/dto/LoginRes.java
@@ -1,0 +1,16 @@
+package com.beautiflow.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LoginRes(
+        String kakaoId,
+        String provider,
+        String isNewUser,
+        String accessToken,
+        String refreshToken
+
+) {
+}

--- a/src/main/java/com/beautiflow/user/repository/UserRepository.java
+++ b/src/main/java/com/beautiflow/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long Id);
 
     Optional<User> findByKakaoId(String kakaoId);
+
+    boolean existsByKakaoId(String kakaoId);
 }

--- a/src/main/java/com/beautiflow/user/service/LoginService.java
+++ b/src/main/java/com/beautiflow/user/service/LoginService.java
@@ -1,0 +1,88 @@
+package com.beautiflow.user.service;
+
+import com.beautiflow.global.common.error.CommonErrorCode;
+import com.beautiflow.global.common.error.UserErrorCode;
+import com.beautiflow.global.common.exception.BeautiFlowException;
+import com.beautiflow.global.common.util.JWTUtil;
+import com.beautiflow.global.common.util.RedisTokenUtil;
+import com.beautiflow.user.domain.User;
+import com.beautiflow.user.dto.LoginReq;
+import com.beautiflow.user.dto.LoginRes;
+import com.beautiflow.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final RedisTokenUtil redisTokenUtil;
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+
+    public LoginRes login(LoginReq loginReq) {
+
+        if (!StringUtils.hasText(loginReq.loginKey())) {
+            throw new BeautiFlowException(UserErrorCode.LOGIN_KEY_REQUIRED);
+        }
+
+        String json = redisTokenUtil.getValues(loginReq.loginKey());
+
+        if (!StringUtils.hasText(json)) {
+            throw new BeautiFlowException(UserErrorCode.LOGIN_KEY_REQUIRED);
+        }
+
+        //redisTokenUtil.deleteValues(loginReq.loginKey()); 개발환경에서 주석처리
+
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            String kakaoId = node.path("kakaoId").asText();
+            String provider = node.path("provider").asText();
+
+            boolean exists = userRepository.existsByKakaoId(kakaoId);
+            System.out.println(kakaoId + ":" + provider + ":" + exists);
+
+            if (!exists) {
+                return LoginRes.builder()
+                        .kakaoId(kakaoId)
+                        .provider(provider)
+                        .isNewUser("true")
+                        .accessToken(null)
+                        .refreshToken(null)
+                        .build();
+            } else {
+
+                User user = userRepository.findByKakaoId(kakaoId).orElse(null);
+
+                if (user != null) {
+
+                    String accessToken = jwtUtil.createAccessToken(provider, kakaoId, user.getId());
+                    String refreshToken = jwtUtil.createRefreshToken(kakaoId, user.getId());
+
+                    return LoginRes.builder()
+                            .kakaoId(kakaoId)
+                            .provider(provider)
+                            .isNewUser("false")
+                            .accessToken(accessToken)
+                            .refreshToken(refreshToken)
+                            .build();
+
+
+                } else {
+                    throw new BeautiFlowException(UserErrorCode.USER_NOT_FOUND);
+                }
+
+
+            }
+        } catch (Exception e) {
+            throw new BeautiFlowException(CommonErrorCode.REDIS_CONNECTION_FAILED);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number

close #156

## 🪐 작업 내용

쿠키를 사용해서 로그인 응답을 프론트에 전달하는데 문제가 발생하여 카카오에서 로그인하여 유저 정보를 발급받은 뒤 바로 쿠키로 프론트에 전달하는 방식을 변경하였습니다.
카카오에서 전달받은 정보로 kakaoId, provider, isUserAlreadyExist 여부를 포함한 payload를 생성하고, 이 데이터를 짧은 TTL로 Redis에 저장합니다. 
Redis 키 (loginKey) 는 login: UUID형태이며 로그인이 성공한 뒤 서버는 프론트엔드 콜백 URL로 /?loginKey=... 형태로 리다이렉트합니다.
프론트는 URL에서 loginKey를 추출하여 API로 전달하고, 서버는 Redis에서 해당 키를 조회 후 즉시 삭제하며 신규 유저인지 여부에 따라 다른 응답을 Body에 넣어 전달합니다.

## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
